### PR TITLE
Freezing Armour

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ https://github.com/b-crawl/bcrawl/releases
   - Lee's Rapid Deconstruction still breaks walls.
   - Bolt of Cold and Throw Frost have +1 range.
   - Lightning Bolt has better accuracy.
+  - v1.1: Ozocubu's Armour now works with any armour and freezes melee attackers, but only lasts a few turns and gives a smaller AC bonus.
 
 #### Removed Spells
   - Summon Guardian Golem

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ https://github.com/b-crawl/bcrawl/releases
   - Archaeologists start with a crate and a dusty tome. The tome reveals itself to be a random skill manual at XL 3, and when the manual is finished, the crate unlocks and gives the player a related artifact.
   - Necromancers start with Bolt of Draining.
   - 'Assassin' has been renamed to 'Rogue'.
+  - v1.1: Skalds have a reworked Ozocubu's Armour instead of Shroud of Golubria.
 
 #### Features
   - All items are automatically identified if the player has a rune.

--- a/crawl-ref/source/book-data.h
+++ b/crawl-ref/source/book-data.h
@@ -140,10 +140,10 @@ static const vector<spell_type> spellbook_templates[] =
 #if TAG_MAJOR_VERSION > 34
 {   // Book of Battle
     SPELL_INFUSION,
-    SPELL_SHROUD_OF_GOLUBRIA,
     SPELL_SONG_OF_SLAYING,
     SPELL_SPECTRAL_WEAPON,
     SPELL_REGENERATION,
+    SPELL_OZOCUBUS_ARMOUR,
 },
 #endif
 {   // Book of Clouds
@@ -226,10 +226,10 @@ static const vector<spell_type> spellbook_templates[] =
 
 {   // Book of Battle
     SPELL_INFUSION,
-    SPELL_SHROUD_OF_GOLUBRIA,
     SPELL_SONG_OF_SLAYING,
     SPELL_SPECTRAL_WEAPON,
     SPELL_REGENERATION,
+    SPELL_OZOCUBUS_ARMOUR,
 },
 #endif
 

--- a/crawl-ref/source/dat/descript/spells.txt
+++ b/crawl-ref/source/dat/descript/spells.txt
@@ -961,11 +961,9 @@ impact. Its damage partially bypasses armour.
 %%%%
 Ozocubu's Armour spell
 
-Envelops the caster's body in a protective layer of thick ice, granting a
-substantial bonus to armour as long as they remain in their current location.
-The ice will crack and fall away if the caster moves to a new position. The
-spell will not function for casters already wearing heavy armour (any body
-armour with an encumbrance rating of 5 or more).
+Envelops the caster's body in a freezing cloud of ice for a short time,
+granting a bonus to armour and freezing melee attackers.
+The spell will break if the caster moves to a new position.
 %%%%
 Ozocubu's Refrigeration spell
 

--- a/crawl-ref/source/delay.cc
+++ b/crawl-ref/source/delay.cc
@@ -747,15 +747,6 @@ void ArmourOnDelay::finish()
 #endif
     mprf("You finish putting on %s.", armour.name(DESC_YOUR).c_str());
 
-    if (eq_slot == EQ_BODY_ARMOUR)
-    {
-        if (you.duration[DUR_ICY_ARMOUR] != 0
-            && !is_effectively_light_armour(&armour))
-        {
-            remove_ice_armour();
-        }
-    }
-
     equip_item(eq_slot, armour.link);
 
     check_item_hint(armour, old_talents);

--- a/crawl-ref/source/melee-attack.cc
+++ b/crawl-ref/source/melee-attack.cc
@@ -3031,7 +3031,7 @@ void melee_attack::mons_apply_attack_flavour()
 
 void melee_attack::do_passive_freeze()
 {
-    if ((you.has_mutation(MUT_PASSIVE_FREEZE) || duration[DUR_ICY_ARMOUR])
+    if ((you.has_mutation(MUT_PASSIVE_FREEZE) || you.duration[DUR_ICY_ARMOUR])
         && attacker->alive()
         && adjacent(you.pos(), attacker->as_monster()->pos()))
     {

--- a/crawl-ref/source/melee-attack.cc
+++ b/crawl-ref/source/melee-attack.cc
@@ -3031,7 +3031,7 @@ void melee_attack::mons_apply_attack_flavour()
 
 void melee_attack::do_passive_freeze()
 {
-    if (you.has_mutation(MUT_PASSIVE_FREEZE)
+    if ((you.has_mutation(MUT_PASSIVE_FREEZE) || duration[DUR_ICY_ARMOUR])
         && attacker->alive()
         && adjacent(you.pos(), attacker->as_monster()->pos()))
     {

--- a/crawl-ref/source/melee-attack.cc
+++ b/crawl-ref/source/melee-attack.cc
@@ -251,6 +251,13 @@ bool melee_attack::handle_phase_attempted()
     return true;
 }
 
+bool melee_attack::handle_phase_blocked()
+{
+    do_passive_freeze();
+
+    return attack::handle_phase_blocked();
+}
+
 bool melee_attack::handle_phase_dodged()
 {
     did_hit = false;
@@ -3047,7 +3054,7 @@ void melee_attack::do_passive_freeze()
         if (!hurted)
             return;
 
-        simple_monster_message(*mon, " is very cold.");
+        simple_monster_message(*mon, " is frozen.");
 
 #ifndef USE_TILE_LOCAL
         flash_monster_colour(mon, LIGHTBLUE, 200);

--- a/crawl-ref/source/melee-attack.h
+++ b/crawl-ref/source/melee-attack.h
@@ -54,6 +54,7 @@ public:
 private:
     /* Attack phases */
     bool handle_phase_attempted() override;
+    bool handle_phase_blocked() override;
     bool handle_phase_dodged() override;
     bool handle_phase_hit() override;
     bool handle_phase_damaged() override;

--- a/crawl-ref/source/movement.cc
+++ b/crawl-ref/source/movement.cc
@@ -52,7 +52,7 @@ void remove_ice_armour_movement()
 {
     if (you.duration[DUR_ICY_ARMOUR])
     {
-        mprf(MSGCH_DURATION, "Your icy armour cracks and falls away as "
+        mprf(MSGCH_DURATION, "Your icy armour cracks and dissipates as "
                              "you move.");
         you.duration[DUR_ICY_ARMOUR] = 0;
         you.redraw_armour_class = true;

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -6154,7 +6154,7 @@ int player::armour_class(bool /*calc_unid*/) const
     int AC = base_ac(scale);
 
     if (duration[DUR_ICY_ARMOUR])
-        AC += 500 + you.props[ICY_ARMOUR_KEY].get_int() * 8;
+        AC += 400;
 
     if (has_mutation(MUT_ICEMAIL))
         AC += 100 * player_icemail_armour_class();

--- a/crawl-ref/source/spl-selfench.cc
+++ b/crawl-ref/source/spl-selfench.cc
@@ -70,7 +70,7 @@ spret_type ice_armour(int pow, bool fail)
     else if (you.form == transformation::ice_beast)
         mpr("Your icy body feels more resilient.");
     else
-        mpr("A film of ice covers your body!");
+        mpr("A cloud of ice covers your body!");
 
     if (you.attribute[ATTR_BONE_ARMOUR] > 0)
     {
@@ -78,7 +78,8 @@ spret_type ice_armour(int pow, bool fail)
         mpr("Your corpse armour falls away.");
     }
 
-    you.increase_duration(DUR_ICY_ARMOUR, random_range(40, 50), 50);
+    int dur = 1 + div_rand_round(pow, 25);
+    you.increase_duration(DUR_ICY_ARMOUR, dur, dur);
     you.props[ICY_ARMOUR_KEY] = pow;
     you.redraw_armour_class = true;
 

--- a/crawl-ref/source/spl-selfench.cc
+++ b/crawl-ref/source/spl-selfench.cc
@@ -78,7 +78,7 @@ spret_type ice_armour(int pow, bool fail)
         mpr("Your corpse armour falls away.");
     }
 
-    int dur = 1 + div_rand_round(pow, 25);
+    int dur = 2 + div_rand_round(pow, 20);
     you.increase_duration(DUR_ICY_ARMOUR, dur, dur);
     you.props[ICY_ARMOUR_KEY] = pow;
     you.redraw_armour_class = true;

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -1228,8 +1228,6 @@ string spell_uselessness_reason(spell_type spell, bool temp, bool prevent,
         break;
 
     case SPELL_OZOCUBUS_ARMOUR:
-        if (temp && !player_effectively_in_light_armour())
-            return "your body armour is too heavy.";
         if (temp && you.form == transformation::statue)
             return "the film of ice won't work on stone.";
         if (temp && you.duration[DUR_FIRE_SHIELD])


### PR DESCRIPTION
This makes Ozocubu's Armour a very-short-duration buff giving +4 AC and freezing enemies (like the spell Freeze) that hit or are blocked.

It also replaces Shroud with this in the Skald book.