### PR TITLE
Correct starting item for Spelunker

### DIFF
--- a/crawl-ref/source/job-data.h
+++ b/crawl-ref/source/job-data.h
@@ -257,7 +257,7 @@ static const map<job_type, job_def> job_data =
     "Sp", "Spelunker",
     4, 4, 4,
     { SP_HUMAN, SP_KOBOLD, SP_SPRIGGAN, SP_VAMPIRE, SP_DUSK_WALKER, SP_VINE_STALKER, SP_SAND_DWARF, },
-    { "dagger plus:1", "leather armour", "boots", "wand of digging charges:10", "lamp of fire", "scroll of noise" },
+    { "dagger plus:1", "leather armour", "pair of boots", "wand of digging charges:10", "lamp of fire", "scroll of noise" },
     WCHOICE_NONE,
     { { SK_STEALTH, 3 }, { SK_WEAPON, 2 }, { SK_FIGHTING, 2 }, { SK_SPELLCASTING, 2 },
       { SK_HEXES, 2 }, { SK_TRANSMUTATIONS, 2 }, { SK_EARTH_MAGIC, 2 }, { SK_EVOCATIONS, 2 }, },} },


### PR DESCRIPTION
This fixes the Spelunker background not getting a pair of boots as starting items. Thanks!