### PR TITLE
Give Spider- and Tree-form stabbing bonuses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -350,6 +350,7 @@
   - v1.40: The Invisibility spell has less duration scaling with power. It's now equivalent to a potion of invisibility at 80 spell power instead of 40.
   - v1.40: Scorpion Form gives rF++ and rCorr.
   - v1.40: Spellforged servitors have rF+ rC+ instead of rF++ rC++.
+  - v1.??: Spiderform and Treeform can stab better, Treeform is stealthier.
 
 #### Removed Spells
   - Summon Guardian Golem

--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -1039,7 +1039,7 @@ void attack::stab_message()
         if (coinflip())
         {
             mprf("You %s %s from a blind spot!",
-                  (you.species == SP_FELID) ? "pounce on" : "strike",
+                  (you.species == SP_FELID || you.form == transformation::spider) ? "pounce on" : "strike",
                   defender->name(DESC_THE).c_str());
         }
         else
@@ -1057,13 +1057,13 @@ void attack::stab_message()
         else
         {
             mprf("You %s %s from behind!",
-                  (you.species == SP_FELID) ? "pounce on" : "strike",
+                  (you.species == SP_FELID || you.form == transformation::spider) ? "pounce on" : "strike",
                   defender->name(DESC_THE).c_str());
         }
         break;
     case 2:
     case 1:
-        if (you.species == SP_FELID && coinflip())
+        if ((you.species == SP_FELID || you.form == transformation::spider) && coinflip())
         {
             mprf("You pounce on the unaware %s!",
                  defender->name(DESC_PLAIN).c_str());

--- a/crawl-ref/source/dat/descript/spells.txt
+++ b/crawl-ref/source/dat/descript/spells.txt
@@ -722,7 +722,8 @@ Tree Form spell
 
 Transforms the caster into a tree, gaining innate armour, increased health,
 extra unarmed combat damage, and immunity to negative energy. However, this
-form cannot move or teleport, and cannot be cancelled at will.
+form cannot move or teleport, and cannot be cancelled at will. This form is
+extra stealthy, and good at attacking unaware enemies.
 
 While transformed, any equipped armour except shields is melded.
 %%%%
@@ -1331,6 +1332,7 @@ Spider Form spell
 
 Transforms the caster into a venomous, spider-like creature. The caster becomes
 highly evasive and gains a poisonous bite, but gains vulnerability to poison.
+The caster also receives stabbing bonuses as if wielding a short blade.
 
 While transformed, any equipped weapons and armour are melded, and casting
 spells becomes slightly more difficult.

--- a/crawl-ref/source/melee-attack.cc
+++ b/crawl-ref/source/melee-attack.cc
@@ -2328,6 +2328,8 @@ bool melee_attack::player_good_stab()
     return wpn_skill == SK_SHORT_BLADES
            || you.get_mutation_level(MUT_PAWS)
            || player_equip_unrand(UNRAND_BOOTS_ASSASSIN)
+           || you.form == transformation::spider
+           || you.form == transformation::tree
               && (!weapon || is_melee_weapon(*weapon));
 }
 

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -3449,7 +3449,7 @@ int player_stealth()
         stealth /= umbra_div;
     }
 
-    if (you.form == transformation::shadow)
+    if (you.form == transformation::shadow || you.form == transformation::tree)
         stealth *= 2;
 
     // If you're surrounded by a storm, you're inherently pretty conspicuous.

--- a/crawl-ref/source/spl-data.h
+++ b/crawl-ref/source/spl-data.h
@@ -1222,7 +1222,7 @@ static const struct spell_desc spelldata[] =
     4,
     0,
     -1, -1,
-    6, 0,
+    0, 0,
     TILEG_TREE_FORM,
 },
 


### PR DESCRIPTION
Spiderform now stabs like felids do, no other changes. Treeform now always stabs well, as if wearing UNRAND_BOOTS_ASSASSIN, is silent to cast, and doubles your stealth.

Stabby spiderform is there to give players more options, whether as wizards using spiderform + noxious clouds, as early game transmuters (ab)using passwall, or in the late game to alternate with Scorpionform.

Stabby treeform is not expected to be useful very often, but I think it will be extremely funny when it is made useful.